### PR TITLE
Added link to homepage on the logo

### DIFF
--- a/frontend/components/Header.tsx
+++ b/frontend/components/Header.tsx
@@ -73,9 +73,10 @@ export default function Header() {
       <div className="max-w-6xl mx-auto px-4 h-14 flex items-center justify-between">
 
         {/* Brand name — updated */}
-        <span className="text-white font-bold text-lg tracking-wide">
+        <Link href="/" className="text-white font-bold text-lg tracking-wide hover:opacity-80 transition-opacity">
           Space Supremacy – Transcendence
-        </span>
+        </Link>
+
 
         {user && (
           <div className="relative">


### PR DESCRIPTION
added a link back to the homepage behind the logo in the frontend header

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The header brand is now clickable, allowing users to navigate back to the home page with an interactive hover effect.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->